### PR TITLE
Backfill missing lab metadata (6 files)

### DIFF
--- a/Instructions/Labs/Lab_00_setup.md
+++ b/Instructions/Labs/Lab_00_setup.md
@@ -1,3 +1,16 @@
+---
+lab:
+  title: Follow along using sample data with Microsoft 365 Copilot
+  description: 'Throughout these labs, we''ll be crafting prompts for Microsoft 365
+    Copilot that reference the following files:'
+  duration: 26 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Microsoft 365
+  - Microsoft 365 Copilot
+---
+
 # Follow along using sample data with Microsoft 365 Copilot
 
 Throughout these labs, we'll be crafting prompts for Microsoft 365 Copilot that reference the following files:

--- a/Instructions/Labs/Lab_01_Unleash_Productivity_Copilot_Chat.md
+++ b/Instructions/Labs/Lab_01_Unleash_Productivity_Copilot_Chat.md
@@ -1,9 +1,13 @@
 ---
 lab:
   title: 'Lab 1: Ace your interview with Copilot Chat'
-  description: 'Microsoft 365 Copilot – Use Copilot Chat to prepare for an interview'
-  level: 'Lab 100'
+  description: Microsoft 365 Copilot – Use Copilot Chat to prepare for an interview
+  level: Lab 100
   duration: '30'
+  islab: true
+  primarytopics:
+  - Microsoft 365
+  - Microsoft 365 Copilot
 ---
 
 # Lab 1 - Ace your interview with Copilot Chat

--- a/Instructions/Labs/Lab_02_Build_Presentation_PowerPoint.md
+++ b/Instructions/Labs/Lab_02_Build_Presentation_PowerPoint.md
@@ -1,9 +1,14 @@
 ---
 lab:
   title: 'Lab 2: Build a presentation from start to finish with Copilot in PowerPoint'
-  description: 'Microsoft 365 Copilot – Explore how Copilot in PowerPoint can be used to help you build a presentation from start to finish.'
-  level: 'Lab 100'
+  description: Microsoft 365 Copilot – Explore how Copilot in PowerPoint can be used
+    to help you build a presentation from start to finish.
+  level: Lab 100
   duration: '30'
+  islab: true
+  primarytopics:
+  - Microsoft 365
+  - Microsoft 365 Copilot
 ---
 
 # Lab 2 - Build a presentation from start to finish with Copilot in PowerPoint

--- a/Instructions/Labs/Lab_03_Write_Document_Word.md
+++ b/Instructions/Labs/Lab_03_Write_Document_Word.md
@@ -1,10 +1,16 @@
 ---
 lab:
   title: 'Lab 3: Draft, improve, and share your document with Copilot in Word'
-  description: 'Microsoft 365 Copilot – Use Copilot in Word to create, edit, and share a document.'
-  level: 'Lab 100'
+  description: Microsoft 365 Copilot – Use Copilot in Word to create, edit, and share
+    a document.
+  level: Lab 100
   duration: '30'
+  islab: true
+  primarytopics:
+  - Microsoft 365
+  - Microsoft 365 Copilot
 ---
+
 # Lab 3 - Draft, improve, and share your document with Copilot in Word
 
 Imagine you're a project manager tasked with creating a comprehensive project report for your company's new Mystic Spice Premium Chai Tea. In this Lab, you use Microsoft Word to draft the report, convert text to a table for easier readability, and summarize your document to ensure clear, concise content.

--- a/Instructions/Labs/Lab_04_Collaborate_with_Teams.md
+++ b/Instructions/Labs/Lab_04_Collaborate_with_Teams.md
@@ -1,10 +1,16 @@
 ---
 lab:
   title: 'Lab 4: Manage collaboration from start to finish'
-  description: 'Microsoft 365 Copilot – Learn how Copilot in Outlook can help you manage collaboration with your team.'
-  level: 'Lab 100'
+  description: Microsoft 365 Copilot – Learn how Copilot in Outlook can help you manage
+    collaboration with your team.
+  level: Lab 100
   duration: '30'
+  islab: true
+  primarytopics:
+  - Microsoft 365
+  - Microsoft 365 Copilot
 ---
+
 # Lab 4 - Manage collaboration from start to finish
 
 Imagine you're a manager at Contoso. Your team relies on effective communication to collaborate and achieve goals. You want to rally the team behind a new idea for the Contoso Connect product launch, and need to send a message to your team about how to incorporate this idea before the product launch deadline. Use Copilot to draft, rewrite, and adjust your message to ensure it's clear, concise, and professional. Then, use Copilot in Outlook to schedule your meeting.

--- a/Instructions/Labs/Lab_05_Boost_productivity_Excel.md
+++ b/Instructions/Labs/Lab_05_Boost_productivity_Excel.md
@@ -1,10 +1,17 @@
 ---
 lab:
-  title: 'Lab 5: Boost your productivity with data-driven decisions with Copilot in Excel'
-  description: 'Microsoft 365 Copilot – See how Copilot in Excel empowers you to explore and analyze sales data.'
-  level: 'Lab 100'
+  title: 'Lab 5: Boost your productivity with data-driven decisions with Copilot in
+    Excel'
+  description: Microsoft 365 Copilot – See how Copilot in Excel empowers you to explore
+    and analyze sales data.
+  level: Lab 100
   duration: '30'
+  islab: true
+  primarytopics:
+  - Microsoft 365
+  - Microsoft 365 Copilot
 ---
+
 # Lab 5 - Boost your productivity with data-driven decisions with Copilot in Excel
 
 Imagine you're a sales manager at Contoso. Your primary responsibility is to analyze sales data and identify trends that can help improve the company's performance. In this hands-on Lab, you'll use Copilot in Excel to explore and analyze various aspects of the sales data for Contoso's Chai products.


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 6

- `Instructions/Labs/Lab_00_setup.md` (front_matter_created,normalized_case_keys,title,description,duration,level,islab,primarytopics)
- `Instructions/Labs/Lab_01_Unleash_Productivity_Copilot_Chat.md` (islab,primarytopics)
- `Instructions/Labs/Lab_02_Build_Presentation_PowerPoint.md` (islab,primarytopics)
- `Instructions/Labs/Lab_03_Write_Document_Word.md` (islab,primarytopics)
- `Instructions/Labs/Lab_04_Collaborate_with_Teams.md` (islab,primarytopics)
- `Instructions/Labs/Lab_05_Boost_productivity_Excel.md` (islab,primarytopics)
